### PR TITLE
perf: registerify xhash.RNG.Uint64

### DIFF
--- a/xmath/rand.go
+++ b/xmath/rand.go
@@ -33,14 +33,16 @@ func NewRNG() RNG {
 
 // Uint64 produces a 64-bit pseudo-random value.
 func (rng *RNG) Uint64() uint64 {
-	r := bits.RotateLeft64(rng.x*5, 7) * 9
-	t := rng.x << 17
-	rng.y ^= rng.w
-	rng.z ^= rng.x
-	rng.x ^= rng.y
-	rng.w ^= rng.z
-	rng.y ^= t
-	rng.z = bits.RotateLeft64(rng.z, 45)
+	w, x, y, z := rng.w, rng.x, rng.y, rng.z
+	r := bits.RotateLeft64(x*5, 7) * 9
+	t := x << 17
+	y ^= w
+	z ^= x
+	x ^= y
+	w ^= z
+	y ^= t
+	z = bits.RotateLeft64(z, 45)
+	rng.w, rng.x, rng.y, rng.z = w, x, y, z
 	return r
 }
 

--- a/xmath/rand_test.go
+++ b/xmath/rand_test.go
@@ -94,3 +94,16 @@ func graphFill(rng xmath.RNG, degree int) float64 {
 	// Calculate p-value from chi-squared statistic.
 	return mathext.GammaIncRegComp(float64(degree*degree-1)/2, x/2)
 }
+
+var doNotOptimize uint64
+
+func BenchmarkUint64(b *testing.B) {
+	rng := xmath.NewRNG()
+	b.SetBytes(8)
+	b.ResetTimer()
+	var dnopt uint64
+	for i := b.N; i != 0; i-- {
+		dnopt = rng.Uint64()
+	}
+	doNotOptimize = dnopt
+}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/zephyrtronium/xirho/xmath
cpu: AMD Ryzen 5 3600 6-Core Processor
          │   /tmp/old   │           /tmp/new            │
          │    sec/op    │    sec/op     vs base         │
Uint64-12   2.270n ± 23%   1.922n ± 53%  ~ (p=1.000 n=7)

          │   /tmp/old    │            /tmp/new            │
          │      B/s      │      B/s       vs base         │
Uint64-12   3.282Gi ± 30%   3.876Gi ± 50%  ~ (p=1.000 n=7)
```

Unlike LLVM and GCC the go compiler is an extremely limited and extremely conservative understanding of memory side effects. This led to it compiling the memory operation more or less as-is because it's simple understanding lead it to think that maybe the various fields of rng aliases to each other.

Hoisting out to a variable like this allows it to quite easily lift it to SSA since the local variables are never taken as reference.

The old code used to operate directly on the memory fields:
```
MOVQ 0x10(SP), DX
LEAQ 0(DX)(DX*4), BX
ROLQ $0x7, BX
SHLQ $0x11, DX
MOVQ 0x8(SP), SI
XORQ 0x18(SP), SI
XORQ SI, DX
MOVQ SI, 0x18(SP)
MOVQ 0x10(SP), DI
XORQ 0x20(SP), DI
MOVQ DI, 0x20(SP)
XORQ SI, 0x10(SP)
XORQ DI, 0x8(SP)
MOVQ DX, 0x18(SP)
ROLQ $0x2d, DI
MOVQ DI, 0x20(SP)
```
While the new on lifts theses to registers:
```
MOVQ 0x8(SP), DX
MOVQ 0x10(SP), BX
MOVQ 0x18(SP), SI
MOVQ 0x20(SP), DI
LEAQ 0(BX)(BX*4), R8
ROLQ $0x7, R8
MOVQ BX, R9
SHLQ $0x11, BX
XORQ DX, SI
XORQ R9, DI
XORQ SI, R9
XORQ DI, DX
XORQ SI, BX
ROLQ $0x2d, DI
MOVQ DX, 0x8(SP)
MOVQ R9, 0x10(SP)
MOVQ BX, 0x18(SP)
MOVQ DI, 0x20(SP)
```